### PR TITLE
Merge CID pipeline into main

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,7 +1,9 @@
 name: CID
 
 on:
-  # triggered by push events on main only
+  # can be manually triggered
+  workflow_dispatch
+  # automatically triggered by push events on main only
   push:
     branches:
       - 'main'

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,15 +1,15 @@
-name: CI
+name: CID
 
 on:
-  # triggered by push events on all branches except for main
+  # triggered by push events on main only
   push:
     branches:
-      - '**'    # includes everything
-      - '!main' # excludes main
+      - 'main'
 
 jobs:
   # build and run the Docker container to validate the model and generate the documentation
-  build:
+  # then publish the HTML artifacts to GitHub Pages
+  build-deploy:
     # run on Linux to use Docker
     runs-on: ubuntu-latest
 
@@ -36,4 +36,11 @@ jobs:
         with:
           name: Documentation
           path: artifacts
+
+      # publish from GitHub workspace
+      - name: Deploy HTML to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: artifacts
 

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -2,7 +2,7 @@ name: CID
 
 on:
   # can be manually triggered
-  workflow_dispatch
+  workflow_dispatch:
   # automatically triggered by push events on main only
   push:
     branches:

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -4,7 +4,7 @@ on:
   # triggered by push events on main only
   push:
     branches:
-      - 'main'
+      - 'cd-test' # includes cd-test for testing
 
 jobs:
   # build and run the Docker container to validate the model and generate the documentation

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -4,7 +4,7 @@ on:
   # triggered by push events on main only
   push:
     branches:
-      - 'cd-test' # includes cd-test for testing
+      - 'main'
 
 jobs:
   # build and run the Docker container to validate the model and generate the documentation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,11 @@
 name: CI
 
 on:
-  # triggered by push events on all branches except for main
+  # automatically triggered by push events on all branches except for main
   push:
     branches:
       - '**'        # includes everything
       - '!main'     # excludes main
-      - '!cd-test'  # excludes cd-test for testing
 
 jobs:
   # build and run the Docker container to validate the model and generate the documentation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,9 @@ on:
   # triggered by push events on all branches except for main
   push:
     branches:
-      - '**'    # includes everything
-      - '!main' # excludes main
+      - '**'        # includes everything
+      - '!main'     # excludes main
+      - '!cd-test'  # excludes cd-test for testing
 
 jobs:
   # build and run the Docker container to validate the model and generate the documentation

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,4 +37,4 @@ cp -r "/workdir/obc-model/html" ${results_folder}/html_export
 cp -r "/workdir/obc-model/validation" ${results_folder}/validation
 
 # Create index.html from stub
-# sed 's/obc-model/OBC Model/g' index_stub.html > ${results_folder}/index.html
+sed 's/model-name-to-replace/OBC Model/g' index_stub.html > ${results_folder}/index.html

--- a/index_stub.html
+++ b/index_stub.html
@@ -1,0 +1,21 @@
+<!doctype html>
+
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<title>model-name-to-replace artifacts</title>
+	</head>
+
+	<body>
+		<h1>model-name-to-replace artifacts</h1>
+		<p>
+			<a href="html_export/output/">Model HTML export</a><br />
+			<a href="validation/model-name-to-replace/model-name-to-replace.aird/validation-results.html">Model Validation</a>
+		</p>
+		<p>
+			<a href="log.html">Log</a>
+		</p>
+	</body>
+
+</html>
+


### PR DESCRIPTION
This MR creates the files required to configure a CID pipeline duplicating the behaviour of the CI pipeline merged in #13 and deploying the generated HTML documentation to GitHub Pages at every push to main:

- `build-deploy.yml` specifying the same steps as `build.yml` + the GHPages action
- `index_stub.html` outlining a stub index (populated at build time) to make the webpage more navigable

The changes to previously-defined files enable these features and prevent duplicate runs.